### PR TITLE
fix get-started-button alignment

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -505,7 +505,7 @@ header {
   width: 330px;
   background-color: aquamarine;
   padding: 20px 80px;
-  margin-left: 39%;
+  margin-inline: auto;
   margin-bottom: 160px;
   transition: all 0.5s ease;
 }


### PR DESCRIPTION
get-started-button alignment isn't equally centered on screens > 1100px width

screenshot for the issue before:

![Screenshot 2022-11-01 at 14-58-01 Hyprland](https://user-images.githubusercontent.com/69465962/199240287-898c1567-5326-4a4f-9f68-b7613528c090.png)

after fix: 
![Screenshot 2022-11-01 at 14-58-17 Hyprland](https://user-images.githubusercontent.com/69465962/199240363-e295bbf1-a0b9-478c-9bcc-5e5d9c283ec1.png)

