### PR TITLE
Click text get start button

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -504,7 +504,6 @@ header {
 #get-started-button {
   width: 330px;
   background-color: aquamarine;
-  padding: 20px 80px;
   margin-left: 39%;
   margin-bottom: 160px;
   transition: all 0.5s ease;
@@ -522,6 +521,9 @@ header {
   text-decoration: none;
   font-family: "Sofia-Pro-Medium";
   font-size: 22px;
+  padding: 20px;
+  display: block;
+  text-align: center;
 }
 
 


### PR DESCRIPTION
Clicking on the white space inside the get-started-button does nothing, unless clicking on the text as shown in the video below:

https://user-images.githubusercontent.com/69465962/199250827-d9401a83-8a2b-4449-bd4c-1f839e73d16c.mp4

after fixing it, clicking on the white space inside the button works:

https://user-images.githubusercontent.com/69465962/199251250-093815da-2cd9-4f53-a4fa-7220a3d20f7a.mp4
