### PR TITLE
fix and-more overflow on hover

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -452,13 +452,17 @@ header {
 
 .and-more h1 {
   padding-top: 30px;
-  width: 100%;
+  width: fit-content;
+  margin-inline: auto;
   font-size: 53px;
   text-align: center;
-  color: #cfe8f6;
   font-family: "JosefinSans-Regular";
   background-color: #1a1a2e;
   transition: all 0.5s ease;
+}
+
+.and-more a {
+  color: #cfe8f6;
 }
 
 .and-more h1:hover {

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -141,7 +141,9 @@
 </div>
 </div>
 <div class="and-more">
-  <a href="https://github.com/hyprwm/Hyprland#features" style="text-decoration: none;"><h1>And More!</h1></a>
+  <h1>
+    <a href="https://github.com/hyprwm/Hyprland#features" style="text-decoration: none;">And More!</a>
+  </h1>
 </div>
 <div class="get-started">
   <div id="get-started-button"><a href="https://wiki.hyprland.org/Getting-Started/Installation/">Install Hyprland</a></div>


### PR DESCRIPTION
Scaling "And more!" on hover state causing overflow-x to the page by 20% as shown in the video:

https://user-images.githubusercontent.com/69465962/199300323-745c4ce4-9ee4-429a-a2cf-420b61b22935.mp4

Changing its `width` to `fit-content` and center it with `margin: auto` fixed the issue...