### PR TITLE
Smoothly transition opacity of `.feature-image`

### DIFF
--- a/src/routes/FeaturesSlice.svelte
+++ b/src/routes/FeaturesSlice.svelte
@@ -175,6 +175,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		transition: opacity 180ms ease-in-out;
 
 		._wrapper:hover & {
 			opacity: 1;


### PR DESCRIPTION
it annoyed me to no end when i hovered over the images, for them to instantly show up. 
so i fix

i get cookie????