### PR TITLE
Visual improvements for mobile (+ alt text)

### DIFF
--- a/src/routes/InstallButton.svelte
+++ b/src/routes/InstallButton.svelte
@@ -1,6 +1,7 @@
 <script>
-	import { onDestroy } from 'svelte'
+    import {onDestroy, onMount} from 'svelte'
 	import ClipboardIcon from '~icons/mingcute/copy-2-line'
+    import {getIsMobile} from "$lib/Helper.mjs";
 
 	/** @type {string} */
 	export let command
@@ -11,12 +12,17 @@
 
 	let isShowingCopied = false
 	let timeoutId
+    let isMobile = false
 
 	async function copyCommand() {
 		await navigator.clipboard.writeText(command).then(() => (isShowingCopied = true))
 		clearTimeout(timeoutId)
 		timeoutId = setTimeout(() => (isShowingCopied = false), 1400)
 	}
+
+    onMount(() => {
+        isMobile = getIsMobile()
+    })
 
 	onDestroy(() => {
 		clearTimeout(timeoutId)
@@ -36,7 +42,9 @@
 		<slot name="imageExtra" />
 	</div>
 
-	<div class="relative mb-2 flex grow flex-col font-mono md:mb-6">
+    <div class="relative mb-2 flex grow flex-col font-mono md:mb-6"
+        class:w-full={isMobile}
+	>
 		<button
 			class="flex min-w-[18rem] items-center justify-center gap-4 rounded-full border border-primary py-3 pl-6 pr-6 text-base font-medium transition-transform active:scale-[1.01]"
 			on:click={$$slots.default ? undefined : copyCommand}

--- a/src/routes/InstallButton.svelte
+++ b/src/routes/InstallButton.svelte
@@ -55,9 +55,11 @@
 						<div class="select-none font-bold text-primary">></div>
 						<span>{command}</span>
 					</div>
-					<ClipboardIcon
-						class="h-6 w-6 text-white  opacity-0 transition-opacity duration-100 hover:!opacity-100 group-hover:opacity-80 group-active:opacity-100"
-					/>
+                    {#if !isMobile}
+                        <ClipboardIcon
+                                class="h-6 w-6 text-white  opacity-0 transition-opacity duration-100 hover:!opacity-100 group-hover:opacity-80 group-active:opacity-100"
+                        />
+                    {/if}
 				</div>
 			</slot>
 		</button>

--- a/src/routes/InstallButton.svelte
+++ b/src/routes/InstallButton.svelte
@@ -30,7 +30,7 @@
 		<img
 			src={image}
 			class="h-20 w-32 object-contain"
-			alt="Distrubution Logo"
+			alt="The {name} logo"
 			loading="lazy"
 		/>{name}
 		<slot name="imageExtra" />


### PR DESCRIPTION
Addressed a point in #32, made all buttons the same width and hid the `ClipboardIcon` on mobile
Also added more descriptive alt text for the distro logos ("Distrubution Logo" -> "logo of {distribution}"