### PR TITLE
fix blur script

### DIFF
--- a/scripts/generate-blurred-images.mjs
+++ b/scripts/generate-blurred-images.mjs
@@ -7,7 +7,7 @@ import { getFileNameWithoutExtension } from '../src/lib/Helper.mjs'
 // This script should be run from the root of the application
 const root = new URL('..', import.meta.url)
 
-const imageDirectories = ['static/imgs/ricing_competitions', 'static/imgs/plugins/logos']
+const imageDirectories = ['static/imgs/ricing_competitions', 'static/plugins-data/logos']
 const generatedPrefix = 'generated_'
 // This value seems to work well
 const maxBrightness = 65535


### PR DESCRIPTION
Fixes the blur script, so that it will build if the blurred images are missing.
If you already have the repo clones, run `pnpm postinstall` to run the script again