### PR TITLE
fix overflow on mobile

### DIFF
--- a/src/lib/components/news-thumb.svelte
+++ b/src/lib/components/news-thumb.svelte
@@ -12,7 +12,7 @@
 		<div class="flex flex-col gap-4 text-sm font-medium text-slate-400">
 			<p class="font-bold text-slate-400">{formatDate(entry.date)}</p>
 		</div>
-		<h2 class="title text-4xl font-bold hover:text-slate-200 md:text-5xl lg:text-6xl">
+		<h2 class="title text-3xl font-bold hover:text-slate-200 md:text-5xl lg:text-6xl">
 			<a href={link}>{entry.title}</a>
 		</h2>
 		<a

--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -35,7 +35,7 @@
 {#if data.other.length > 0}
 	<section class="mx-auto mt-72 max-w-screen-lg">
 		<Title class="mb-6"><span slot="title">More news</span></Title>
-		<ul class="grid grid-cols-2 gap-x-7 gap-y-16">
+		<ul class="grid grid-cols-2 gap-x-7 gap-y-16 overflow-auto">
 			{#each data.other as entry}
 				<NewsThumb {entry} />
 			{/each}


### PR DESCRIPTION
A news article on mobile would show black bar due to overflow.
before:
 
![original](https://github.com/hyprwm/hyprland-website/assets/62998174/7aca5902-425b-4b33-8530-0319f0a142dc)

this PR addresses this.
after:
![after](https://github.com/hyprwm/hyprland-website/assets/62998174/ce79cb27-37d8-4fac-ae86-50fb17f384ec)
