### PR TITLE
Fixed link rot

### DIFF
--- a/src/routes/hall_of_fame/rices.js
+++ b/src/routes/hall_of_fame/rices.js
@@ -42,10 +42,10 @@ export const contests = [
 		color: 'orange',
 		rices: [
 			{
-				name: 'Summer Gruv',
+				name: 'Hybrid Summer',
 				creator: 'end_4',
 				pretitel: '#1',
-				dotfilesLink: 'https://github.com/end-4/dots-hyprland/tree/summer-gruv',
+				dotfilesLink: 'https://github.com/end-4/dots-hyprland/tree/archive/hybrid-summer',
 				creatorProfilePicture: 'https://avatars.githubusercontent.com/u/97237370?s=24&v=4',
 				thumbnail: '/imgs/ricing_competitions/2/end_4.webp'
 			},


### PR DESCRIPTION
summer-gruv on the hall of fame leads to a 404. I swapped the link for the archive where it is now stored and changed the name to what it is named in the archive