### PR TITLE
restyle news slice

### DIFF
--- a/src/lib/components/news-thumb.svelte
+++ b/src/lib/components/news-thumb.svelte
@@ -1,5 +1,5 @@
 <script>
-	import ArrowRight from '~icons/mingcute/arrow-right-circle-line'
+	import ArrowRightUpFill from '~icons/mingcute/arrow-right-up-line'
 
 	import { animateIn, formatDate } from '$lib/Helper.ts'
 	export let entry
@@ -7,18 +7,24 @@
 	$: link = `/news/${entry.slug}`
 </script>
 
-<li class="flex gap-14" use:animateIn={{ fade: 0, slide: 24 }}>
-	<article class="flex flex-col gap-4 rounded">
-		<div class="flex flex-col gap-4 text-sm font-medium text-slate-400">
-			<p class="font-bold text-slate-400">{formatDate(entry.date)}</p>
+<li class="flex" use:animateIn={{ fade: 0, slide: 24 }}>
+	<article
+			class="flex w-full flex-col justify-between gap-3 rounded md:flex-row md:rounded-3xl md:bg-gradient-to-tr md:from-cyan-500/10 md:to-transparent md:p-8 md:shadow-xl md:outline md:outline-1 md:outline-sky-500/30"
+	>
+		<div>
+			<div class="flex flex-col gap-4 font-medium text-slate-400">
+				<p class="font-bold text-slate-400">{formatDate(entry.date)}</p>
+			</div>
+			<h2 class="title text-xl font-bold hover:text-slate-200 md:text-2xl lg:text-3xl">
+				<a href={link}>{entry.title}</a>
+			</h2>
 		</div>
-		<h2 class="title text-3xl font-bold hover:text-slate-200 md:text-5xl lg:text-6xl">
-			<a href={link}>{entry.title}</a>
-		</h2>
 		<a
 			href={link}
-			class="group flex max-w-max items-center gap-4 font-medium text-slate-300 transition-all hover:text-white"
-			>Read up <ArrowRight class="transition-transform group-hover:translate-x-0.5" /></a
-		>
+			class="group flex min-w-max max-w-max flex-row-reverse items-center justify-center gap-2 font-medium text-slate-300 transition-transform hover:text-white md:flex-col"
+		><ArrowRightUpFill
+			class="h-4 w-4 transition-transform group-hover:translate-y-0.5 md:h-9 md:w-9"
+		/> Read up
+		</a>
 	</article>
 </li>

--- a/src/lib/components/news-thumb.svelte
+++ b/src/lib/components/news-thumb.svelte
@@ -1,5 +1,5 @@
 <script>
-	import ArrowRightUpFill from '~icons/mingcute/arrow-right-up-line'
+	import ArrowRight from '~icons/mingcute/arrow-right-circle-line'
 
 	import { animateIn, formatDate } from '$lib/Helper.ts'
 	export let entry
@@ -8,23 +8,25 @@
 </script>
 
 <li class="flex" use:animateIn={{ fade: 0, slide: 24 }}>
-	<article
-			class="flex w-full flex-col justify-between gap-3 rounded md:flex-row md:rounded-3xl md:bg-gradient-to-tr md:from-cyan-500/10 md:to-transparent md:p-8 md:shadow-xl md:outline md:outline-1 md:outline-sky-500/30"
-	>
-		<div>
-			<div class="flex flex-col gap-4 font-medium text-slate-400">
-				<p class="font-bold text-slate-400">{formatDate(entry.date)}</p>
+	<a href={link} class="w-full transition-transform hover:-translate-y-0.5">
+		<article
+			class="flex flex-col justify-between gap-3 rounded hover:outline-sky-500/80 md:flex-row md:rounded-3xl md:bg-gradient-to-tr md:from-cyan-500/10 md:to-transparent md:p-8 md:shadow-xl md:outline md:outline-1 md:outline-sky-500/30"
+		>
+			<div>
+				<div class="flex flex-col gap-4 font-medium text-slate-400">
+					<p class="font-bold text-slate-400">{formatDate(entry.date)}</p>
+				</div>
+				<h2 class="title text-xl font-bold hover:text-slate-200 md:text-2xl lg:text-3xl">
+					{entry.title}
+				</h2>
 			</div>
-			<h2 class="title text-xl font-bold hover:text-slate-200 md:text-2xl lg:text-3xl">
-				<a href={link}>{entry.title}</a>
-			</h2>
-		</div>
-		<a
-			href={link}
-			class="group flex min-w-max max-w-max flex-row-reverse items-center justify-center gap-2 font-medium text-slate-300 transition-transform hover:text-white md:flex-col"
-		><ArrowRightUpFill
-			class="h-4 w-4 transition-transform group-hover:translate-y-0.5 md:h-9 md:w-9"
-		/> Read up
-		</a>
-	</article>
+			<p
+				class="group flex min-w-max max-w-max flex-row-reverse items-center justify-center gap-2 font-medium text-slate-300 transition-transform hover:text-white md:flex-col"
+			>
+				<ArrowRight
+					class="h-4 w-4 transition-transform group-hover:translate-y-0.5 md:h-9 md:w-9"
+				/> Read up
+			</p>
+		</article>
+	</a>
 </li>

--- a/src/routes/home-slices/NewsSlice.svelte
+++ b/src/routes/home-slices/NewsSlice.svelte
@@ -13,7 +13,7 @@
 		<TitleHeading slot="title" class="">Latest news</TitleHeading>
 	</Title>
 
-	<ul class="flex flex-col gap-12">
+	<ul class="mt-8 flex flex-col gap-12">
 		{#each news as entry}
 			<NewsThumb {entry} />
 		{/each}
@@ -27,7 +27,7 @@
 		width: 200%;
 		min-height: 500px;
 		height: 220%;
-		translate: -25% 0%;
+		translate: -25% 0;
 		margin-top: -100px;
 
 		background: url('/imgs/grain.webp'),

--- a/src/routes/home-slices/NewsSlice.svelte
+++ b/src/routes/home-slices/NewsSlice.svelte
@@ -13,7 +13,7 @@
 		<TitleHeading slot="title" class="">Latest news</TitleHeading>
 	</Title>
 
-	<ul class="mt-8 flex flex-col gap-12">
+	<ul class="mt-8 flex flex-col gap-10">
 		{#each news as entry}
 			<NewsThumb {entry} />
 		{/each}


### PR DESCRIPTION
I tried to make the news a bit easier to read.

## Desktop
### before
<img src="https://github.com/user-attachments/assets/2254b9f8-10cc-4d1e-9c8a-79e4f279641b" width="600px">

### after
<img src="https://github.com/user-attachments/assets/2fe89f5f-da1e-42ff-a95a-8178ac9c1743" width="600px">

## Mobile
### before
<img src="https://github.com/user-attachments/assets/3086d0ac-7d4c-4193-a4ce-d7049e4c6ab9" height="400px">

### after
<img src="https://github.com/user-attachments/assets/e843b4da-e15f-456c-b2d8-3911e219e858" height="400px">


