### PR TITLE
UI fix on /news/update47/ page

### DIFF
--- a/src/lib/components/news-thumb.svelte
+++ b/src/lib/components/news-thumb.svelte
@@ -10,7 +10,7 @@
 <li class="flex" use:animateIn={{ fade: 0, slide: 24 }}>
 	<a href={link} class="w-full transition-transform hover:-translate-y-0.5">
 		<article
-			class="flex flex-col justify-between gap-3 rounded hover:outline-sky-500/80 md:flex-row md:rounded-3xl md:bg-gradient-to-tr md:from-cyan-500/10 md:to-transparent md:p-8 md:shadow-xl md:outline md:outline-1 md:outline-sky-500/30"
+			class="flex flex-col h-[100%] justify-between gap-3 rounded hover:outline-sky-500/80 md:flex-row md:rounded-3xl md:bg-gradient-to-tr md:from-cyan-500/10 md:to-transparent md:p-8 md:shadow-xl md:outline md:outline-1 md:outline-sky-500/30"
 		>
 			<div>
 				<div class="flex flex-col gap-4 font-medium text-slate-400">

--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -69,7 +69,7 @@
 			<TitleHeading slot="title" class="">More news</TitleHeading>
 		</Title>
 
-		<ul class="grid grid-cols-2 gap-x-7 gap-y-16 overflow-auto">
+		<ul class="grid grid-cols-2 gap-x-7 gap-y-16">
 			{#each data.other as entry}
 				<NewsThumb {entry} />
 			{/each}


### PR DESCRIPTION
For Issue #88 

Screenshots after fix:
![image](https://github.com/user-attachments/assets/40103810-f761-4c9e-a3df-8a77b7b93cec)
