### PR TITLE
Fix link and content-type on RSS Feed

### DIFF
--- a/src/routes/rss.xml/+server.js
+++ b/src/routes/rss.xml/+server.js
@@ -1,6 +1,6 @@
 import { getNews } from '$lib/posts'
 
-const siteURL = 'https://hyprland.org'
+const siteURL = 'https://hypr.land'
 const siteTitle = 'Hyprland'
 const siteDescription = 'Tiling window manager with the looks'
 
@@ -15,7 +15,7 @@ export const GET = async () => {
 	const options = {
 		headers: {
 			'Cache-Control': 'max-age=0, s-maxage=3600',
-			'Content-Type': 'application/xml'
+			'Content-Type': 'application/rss+xml'
 		}
 	}
 


### PR DESCRIPTION
Recently the hyprland website was changed from `hyprland.org` to `hypr.land`, and the RSS feed link was not updated.

Since then my feed reader, FreshRSS, has been unable to read it, throwing a `cURL error 22: The requested URL returned error: 415` or "Unsupported Media Type" error. 

The [W3C validator](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fhypr.land%2Frss.xml) states "Self reference doesn't match document location." and highlights the line with the old URL.

I've updated the siteURL, as well as set the content-type header in the response from `xml` to `rss+xml`, however if there's a specific reason it was set to just XML it can be removed.