### PR TITLE
remove duplicate sponsor section

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,8 +27,6 @@
 
 		<CommunitySlice communityProfiles={data.communityProfiles} />
 
-		<Sponsors sponsors={data.sponsors} />
-
 		<HyprPerks />
 
 		<Sponsors sponsors={data.sponsors} />


### PR DESCRIPTION
The website contained two sponsor sections. The redundant top section has been removed to eliminate duplication.