### PR TITLE
Fix horizontal scroll bug

### DIFF
--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -17,7 +17,7 @@
 <div class="fancy-top-gradient fad animate-in" />
 
 <article
-	class="mx-auto mt-navbar flex max-w-4xl flex-col gap-4 px-6 pt-20 md:gap-8 md:px-8 lg:mt-32 lg:gap-14"
+	class="mx-auto mt-navbar flex w-full max-w-4xl flex-col gap-4 px-6 pt-20 md:gap-8 md:px-8 lg:mt-32 lg:gap-14"
 >
 	<hgroup
 		class="flex flex-col items-start gap-8 duration-1000 animate-in fade-in-0 slide-in-from-bottom-4"


### PR DESCRIPTION
Good day!
I’ve been using Hyprland as my main window compositor for over a year now, and I really like it. Thank you for your work!

While reading the [April 26 news post](https://hypr.land/news/26_lua/), I noticed a horizontal scroll bug on the page when viewing it on a Pixel 7. Here is an approximate view from DevTools, where the area outside the viewport is highlighted in red:

<img width="1262" height="877" alt="horizonal-scroll-bug" src="https://github.com/user-attachments/assets/7a91e006-2c14-4f9a-ad52-643cf1b0e58b" />


This happens because the `pre` block containing a line of code has `white-space: pre`, so it does not wrap lines, which is expected and correct. However, its parent elements up to `<article>` only have a width limitation via `max-width: 56rem` from `max-w-4xl`, and, as good parents, they do not constrain its growth on mobile devices. As a result, the `overflow-x: auto` property on `pre` is not actually used and element stretches its parents.

I fixed this issue in the least invasive way I could think of, which also seems reasonable to me and now it works as expected:

<img width="997" height="877" alt="horizonal-scroll-fix" src="https://github.com/user-attachments/assets/40a36de9-55ce-4d42-adca-bd777d03b1fa" />


In terms of numbers, the news page now correctly supports widths down to `360px` instead of around `700px`. Below `360px`, the layout starts breaking for other reasons.