### PR TITLE
plugins: update hyprwinwrap url to new repo

### DIFF
--- a/src/content/plugins.toml
+++ b/src/content/plugins.toml
@@ -26,7 +26,7 @@ featured = true
 
 [[plugins]]
 name     = "Hyprwinwrap"
-url      = "https://github.com/hyprwm/hyprland-plugins/tree/main/hyprwinwrap"
+url      = "https://github.com/gen3vra/hyprwinwrap"
 category = "Quality of Life"
 tagline  = "Any app as wallpaper"
 logo     = "/plugins-data/logos/hyprwinwrap-logo.svg"


### PR DESCRIPTION
Updates hyprwinwrap website plugin link to updated https://github.com/gen3vra/hyprwinwrap repo.

I use hyprwinwrap thoroughly in my setup so it will be reliably maintained. 