### PR TITLE
Add hypr-overview plugin

### DIFF
--- a/src/content/plugins.toml
+++ b/src/content/plugins.toml
@@ -173,6 +173,12 @@ url      = "https://github.com/hyprnux/hyprglass"
 category = "Design"
 tagline  = "Liquid-glass like effects, fully customizable"
 
+[[plugins]]
+name     = "hypr-overview"
+url      = "https://github.com/joaogabrielfer/hypr-overview.git"
+category = "Design"
+tagline  = "An overview for the scrolling layout inspired by niri"
+
 # Miscellaneous
 
 [[plugins]]


### PR DESCRIPTION
Adds hypr-overview to the community plugin list.

hypr-overview is a plugin that gives a Niri-like workspace overview.

Repository: https://github.com/joaogabrielfer/hypr-overview

https://github.com/user-attachments/assets/f6dddd40-f0a4-494e-bd9c-463020b9bda6