### PR TITLE
perf(pluginsSlice): stop playing and preloading the hidden video

### DIFF
--- a/src/lib/components/Video.svelte
+++ b/src/lib/components/Video.svelte
@@ -15,6 +15,8 @@
 	/** @type {true | undefined}*/
 	export let autoplay = undefined
 	export let hidden = false
+	/** @type {'auto' | 'metadata' | 'none'}*/
+	export let preload = 'auto'
 	/** @type {string}*/
 	export let videoClass = ''
 	/** @type {string}*/
@@ -57,7 +59,7 @@
 		disableremoteplayback="true"
 		class="rounded-[inherit] {videoClass}"
 		{loop}
-		preload="auto"
+		{preload}
 		{poster}
 		on:click={togglePlay}
 		on:dblclick={makeFullscreen}

--- a/src/routes/home-slices/PluginsSlice.svelte
+++ b/src/routes/home-slices/PluginsSlice.svelte
@@ -52,10 +52,25 @@
 
 	function setActiveItem(index) {
 		activeIndex = index
+		// Play the newly revealed video; below lg (no sync-play) also pause the
+		// previous one so only a single video decodes at a time.
+		videos.forEach((video, i) => {
+			if (i === index) video?.play().catch(() => {})
+			else if (!window.matchMedia('(min-width: 1024px)').matches) video?.pause()
+		})
 	}
 
+	let hasEnteredView = false
+	let isManuallyPaused = false
+
 	function onPlay(currentIndex) {
-		videos.filter((_, index) => index !== currentIndex).forEach((video) => video.play())
+		// Keep the hidden sibling in sync so the hover swap feels instant — but
+		// only where the hover interaction exists (lg+), so phones don't download
+		// and decode a video they never see.
+		if (!window.matchMedia('(min-width: 1024px)').matches) return
+		videos
+			.filter((_, index) => index !== currentIndex)
+			.forEach((video) => video.play().catch(() => {}))
 	}
 	function onPause(activeIndex, currentIndex) {
 		// Prevent infinite loop when active video gets paused and other videos also get paused as a result
@@ -169,7 +184,8 @@
 					<Video
 						sources={[src + '.mp4']}
 						{poster}
-						autoplay
+						autoplay={index === activeIndex ? true : undefined}
+						preload={index === activeIndex ? 'auto' : 'metadata'}
 						muted
 						bind:videoElement={videos[index]}
 						class="z-10 aspect-video origin-left object-cover    object-left shadow-xl  shadow-cyan-700/50    outline-2 outline-cyan-500 duration-500 sm:h-[inherit] sm:rounded-lg sm:outline"
@@ -177,6 +193,19 @@
 						hidden={index !== activeIndex}
 						on:pause={() => onPause(activeIndex, index)}
 						on:play={() => onPlay(index)}
+						on:inview_enter={() => {
+							hasEnteredView = true
+							if (index === activeIndex && !isManuallyPaused) videos[index]?.play().catch(() => {})
+						}}
+						on:inview_leave={() => {
+							// Fires both when scrolling away and when this video gets `hidden`
+							// after an item switch — only the visible video's leave means the
+							// slice left the viewport. It also fires once at the start (see
+							// PreviewRiceSlice), hence the hasEnteredView guard.
+							if (index !== activeIndex) return
+							if (hasEnteredView) isManuallyPaused = !!videos[index]?.paused
+							videos.forEach((video) => video?.pause())
+						}}
 						videoClass="h-[inherit] aspect-video"
 					/>
 				{/each}


### PR DESCRIPTION
Second item from #29 — "Disabling more effects on mobile (especially for `pluginsSlice`)". Independent of #140.

### The problem, measured

Both plugin videos render with `autoplay` + `preload="auto"`, and `onPlay()` sync-plays the hidden sibling so the hover swap feels instant. Headless-Chromium numbers on a 390×844 mobile viewport, dwelling at the slice:

|  | before | after |
| --- | --- | --- |
| mp4 transferred | **~20.7 MB** (8.4 MB of it for the `display:none` video) | **84 KB** |
| videos decoding | 2 (one hidden) | 1 |
| after scrolling past the slice | both keep playing forever | everything paused, active resumes on re-entry |

### What changed

- `autoplay`/`preload="auto"` only on the active video; the hidden one gets `preload="metadata"` (new `preload` prop on `Video.svelte`, default unchanged).
- The sibling sync-play in `onPlay()` is gated to `lg+`, where the hover-swap interaction actually exists.
- Wired up the `inview_enter`/`inview_leave` events that `Video.svelte` already exposes — same pattern `PreviewRiceSlice` already uses, including its initial-`inview_leave` quirk handling: everything pauses when the slice leaves the viewport, the active video resumes on re-entry (unless the user paused it manually).
- Switching items explicitly plays the newly revealed video; below `lg` it also pauses the previous one, so phones decode a single video at a time.

Desktop behavior is preserved (verified: both videos play in view for the instant swap, pause when scrolled past, resume on return) with one bonus: videos now effectively lazy-load, since the initial out-of-view pause stops the eager full download at page load.

Happy to keep going with the other #29 items (`contain` statements need per-slice care — several slices have intentionally overflowing decorations like the `h-[110%]` pattern backgrounds that `contain: paint` would clip, so I kept them out of this one).
